### PR TITLE
Memory efficiency with Numpy array

### DIFF
--- a/dense_trajectory_release_v1.2/DenseTrack.cpp
+++ b/dense_trajectory_release_v1.2/DenseTrack.cpp
@@ -16,7 +16,7 @@ PyObject* densetrack(unsigned char *frames, size_t len, size_t rows, size_t cols
                      int _scale_num, int _init_gap, 
                      int _poly_n, double _poly_sigma)
 {
-    //fprintf(stderr, "C++ - poly_sigma: %f\n", _poly_sigma);
+//	fprintf(stderr, "C++ - poly_sigma: %f\n", _poly_sigma);
 
 	// See http://stackoverflow.com/questions/35774011/segment-fault-when-creating-pylist-new-in-python-c-extention
 	// for why we need line of code below
@@ -24,9 +24,9 @@ PyObject* densetrack(unsigned char *frames, size_t len, size_t rows, size_t cols
 
 	// create a vector of cv::mat to hold frames of video
 	std::vector<Mat> video;
-    for (size_t k = 0; k < len; k++) {
+	for (size_t k = 0; k < len; k++) {
 		Mat frame = Mat(rows, cols, CV_8UC1, (frames + k*rows*cols));
-        video.push_back(frame);
+		video.push_back(frame);
 	}
 
 	track_length = _track_length;
@@ -123,7 +123,7 @@ PyObject* densetrack(unsigned char *frames, size_t len, size_t rows, size_t cols
 //			frame.copyTo(image);
 //			cvtColor(image, prev_grey, CV_BGR2GRAY);
 			frame.copyTo(prev_grey);
-            cvtColor(frame, image, CV_GRAY2BGR);
+			cvtColor(frame, image, CV_GRAY2BGR);
 
 			for(int iScale = 0; iScale < scale_num; iScale++) {
 				if(iScale == 0)
@@ -152,7 +152,7 @@ PyObject* densetrack(unsigned char *frames, size_t len, size_t rows, size_t cols
 		init_counter++;
 //		frame.copyTo(image);
 //		cvtColor(image, grey, CV_BGR2GRAY);
-        frame.copyTo(grey);
+		frame.copyTo(grey);
 		cvtColor(frame, image, CV_GRAY2BGR);
 
 		// compute optical flow for all scales once
@@ -218,7 +218,7 @@ PyObject* densetrack(unsigned char *frames, size_t len, size_t rows, size_t cols
 
 					// Create a copy of the track coordinates because they are normalized by IsValid() call below.
 					std::vector<Point2f> trajectory_copy(trackInfo.length+1);
-                    for(int i = 0; i <= trackInfo.length; ++i)
+					for(int i = 0; i <= trackInfo.length; ++i)
 						trajectory_copy[i] = iTrack->point[i] * fscales[iScale];
 
 					float mean_x(0), mean_y(0), var_x(0), var_y(0), length(0);
@@ -232,8 +232,8 @@ PyObject* densetrack(unsigned char *frames, size_t len, size_t rows, size_t cols
 						PyObject *py_track_mbhy = PyList_New(0);
 
 						// output the original trajectory coordinates mapped to original resolution
-                        for (int i = 0; i != trajectory_copy.size(); i++)
-                            PyList_Append(py_track_coords, Py_BuildValue("[ff]", trajectory_copy[i].x, trajectory_copy[i].y));
+						for (int i = 0; i != trajectory_copy.size(); i++)
+							PyList_Append(py_track_coords, Py_BuildValue("[ff]", trajectory_copy[i].x, trajectory_copy[i].y));
 
 						// for spatio-temporal pyramid
 						float x_pos = std::min<float>(std::max<float>(mean_x/float(seqInfo.width), 0), 0.999);
@@ -253,11 +253,11 @@ PyObject* densetrack(unsigned char *frames, size_t len, size_t rows, size_t cols
 						// Using "N" does NOT increment the reference count. Using "O" WILL increment the reference count
 						// TODO: Need to check if the reference counting below is correct  "(NNNNNNN)"
 //						PyObject *py_track = Py_BuildValue("(NNNNNNN)", py_track_info, py_track_coords,
-                        PyObject *py_track = Py_BuildValue("(ifffffffffNNNNNN)",
-														   frame_num, mean_x, mean_y, var_x, var_y, length,
-														   fscales[iScale], x_pos, y_pos, t_pos,
-														   py_track_coords, py_track_traj, py_track_hog,
-														   py_track_hof, py_track_mbhx, py_track_mbhy);
+						PyObject *py_track = Py_BuildValue("(ifffffffffNNNNNN)",
+										frame_num, mean_x, mean_y, var_x, var_y, length,
+										fscales[iScale], x_pos, y_pos, t_pos,
+										py_track_coords, py_track_traj, py_track_hog,
+										py_track_hof, py_track_mbhx, py_track_mbhy);
 						PyList_Append(py_tracks, py_track);
 					}
 

--- a/dense_trajectory_release_v1.2/Descriptors.h
+++ b/dense_trajectory_release_v1.2/Descriptors.h
@@ -292,24 +292,20 @@ void DrawTrack(const std::vector<Point2f>& point, const int index, const float s
 	circle(image, point0, 2, Scalar(0,0,255), -1, 8, 0);
 }
 
-void PrintDesc(std::vector<float>& desc, DescInfo& descInfo, TrackInfo& trackInfo, PyObject* outList)
+void PrintDesc(std::vector<float>& desc, DescInfo& descInfo, TrackInfo& trackInfo, std::vector<float>& outVec)
 {
-	if (!PyList_Check(outList))
-		fprintf(stderr, "Input is not python list\n");
-	if (PyList_Size(outList) != 0)
-		fprintf(stderr, "Input python list should be empty\n");
-
 	int tStride = cvFloor(trackInfo.length/descInfo.ntCells);
 	float norm = 1./float(tStride);
 	int dim = descInfo.dim;
 	int pos = 0;
+	std::vector<float>(descInfo.ntCells * dim).swap(outVec);
 	for(int i = 0; i < descInfo.ntCells; i++) {
 		std::vector<float> vec(dim);
 		for(int t = 0; t < tStride; t++)
 			for(int j = 0; j < dim; j++)
 				vec[j] += desc[pos++];
 		for(int j = 0; j < dim; j++)
-			PyList_Append(outList, Py_BuildValue("f", vec[j]*norm));
+			outVec[i * dim + j] = vec[j]*norm;
 	}
 }
 

--- a/densetrack.py
+++ b/densetrack.py
@@ -118,13 +118,13 @@ def densetrack(
     # tracks = [dict(zip(ret_fields, track)) for track in data]  # uncomment to return list
     # tracks = pd.DataFrame(data, columns=ret_fields)  # uncomment to return dataframe
 
-    types = (np.int, np.float, np.float, np.float, np.float, np.float, np.float,
-             np.float, np.float, np.float, np.float, np.float, np.float, np.float,
-             np.float, np.float)
-    shapes = (1, 1, 1, 1, 1, 1, 1, 1, 1, 1, (track_length+1,2), (track_length,2),
-              8*nxy_cell*nxy_cell*nt_cell, 9*nxy_cell*nxy_cell*nt_cell, 8*nxy_cell*nxy_cell*nt_cell,
-              8*nxy_cell*nxy_cell*nt_cell)
-    tracks = np.array(data, dtype=list(zip(ret_fields, types, shapes)))
+    # types = (np.int, np.float, np.float, np.float, np.float, np.float, np.float,
+    #          np.float, np.float, np.float, np.float, np.float, np.float, np.float,
+    #          np.float, np.float)
+    # shapes = (1, 1, 1, 1, 1, 1, 1, 1, 1, 1, (track_length+1,2), (track_length,2),
+    #           8*nxy_cell*nxy_cell*nt_cell, 9*nxy_cell*nxy_cell*nt_cell, 8*nxy_cell*nxy_cell*nt_cell,
+    #           8*nxy_cell*nxy_cell*nt_cell)
+    # tracks = np.array(data, dtype=list(zip(ret_fields, types, shapes)))
 
-    return tracks
-
+    # return tracks
+    return data


### PR DESCRIPTION
When using your module, I noticed that the GIL is held the whole time during the long computation of tracks. That would prevent multi-threading that could otherwise process multiple videos in parallel in the same process. While multi-processing could do the same, it's nice to make real multi-threading available were possible.

While making those changes, I noticed that the maximum resident memory was 18 GB for a video with 1,100 frames and 789,000 tracks. Returning a Numpy array instead of a Python list reduced the maximum resident memory to 4.3 GB and reduced the run time by 25% to less than 7 minutes. Please note that I'm returning `float32` in the Numpy array because the C++ data structures use `float`.

I left the PR as three commits so that the changes are clearer.