### PR TITLE
Parameter for saving images with overlaid tracks

### DIFF
--- a/dense_trajectory_release_v1.2/DenseTrack.cpp
+++ b/dense_trajectory_release_v1.2/DenseTrack.cpp
@@ -363,23 +363,26 @@ PyObject* densetrack(unsigned char *frames, size_t len, size_t rows, size_t cols
 	}
 
 	int cell_size = nxy_cell * nxy_cell * nt_cell;
-	PyObject* dtype = PyList_New(0);
-	PyList_Append(dtype, Py_BuildValue("(s, s, i)", "frame_num", "i", 1));
-	PyList_Append(dtype, Py_BuildValue("(s, s, i)", "mean_x", "f", 1));
-	PyList_Append(dtype, Py_BuildValue("(s, s, i)", "mean_y", "f", 1));
-	PyList_Append(dtype, Py_BuildValue("(s, s, i)", "var_x", "f", 1));
-	PyList_Append(dtype, Py_BuildValue("(s, s, i)", "var_y", "f", 1));
-	PyList_Append(dtype, Py_BuildValue("(s, s, i)", "length", "f", 1));
-	PyList_Append(dtype, Py_BuildValue("(s, s, i)", "scale", "f", 1));
-	PyList_Append(dtype, Py_BuildValue("(s, s, i)", "x_pos", "f", 1));
-	PyList_Append(dtype, Py_BuildValue("(s, s, i)", "y_pos", "f", 1));
-	PyList_Append(dtype, Py_BuildValue("(s, s, i)", "t_pos", "f", 1));
-	PyList_Append(dtype, Py_BuildValue("(s, s, (i, i))", "coords", "f", track_length + 1, 2));
-	PyList_Append(dtype, Py_BuildValue("(s, s, (i, i))", "trajectory", "f", track_length, 2));
-	PyList_Append(dtype, Py_BuildValue("(s, s, i)", "hog", "f", 8 * cell_size));
-	PyList_Append(dtype, Py_BuildValue("(s, s, i)", "hof", "f", 9 * cell_size));
-	PyList_Append(dtype, Py_BuildValue("(s, s, i)", "mbh_x", "f", 8 * cell_size));
-	PyList_Append(dtype, Py_BuildValue("(s, s, i)", "mbh_y", "f", 8 * cell_size));
+	// PyList_Append increases the ref count (unlike PyList_SetItem)
+	// https://stackoverflow.com/questions/3512414/does-this-pylist-appendlist-py-buildvalue-leak
+	PyObject* dtype = PyList_New(16);
+	int idx = 0;
+	PyList_SetItem(dtype, idx++, Py_BuildValue("(s, s, i)", "frame_num", "i", 1));
+	PyList_SetItem(dtype, idx++, Py_BuildValue("(s, s, i)", "mean_x", "f", 1));
+	PyList_SetItem(dtype, idx++, Py_BuildValue("(s, s, i)", "mean_y", "f", 1));
+	PyList_SetItem(dtype, idx++, Py_BuildValue("(s, s, i)", "var_x", "f", 1));
+	PyList_SetItem(dtype, idx++, Py_BuildValue("(s, s, i)", "var_y", "f", 1));
+	PyList_SetItem(dtype, idx++, Py_BuildValue("(s, s, i)", "length", "f", 1));
+	PyList_SetItem(dtype, idx++, Py_BuildValue("(s, s, i)", "scale", "f", 1));
+	PyList_SetItem(dtype, idx++, Py_BuildValue("(s, s, i)", "x_pos", "f", 1));
+	PyList_SetItem(dtype, idx++, Py_BuildValue("(s, s, i)", "y_pos", "f", 1));
+	PyList_SetItem(dtype, idx++, Py_BuildValue("(s, s, i)", "t_pos", "f", 1));
+	PyList_SetItem(dtype, idx++, Py_BuildValue("(s, s, (i, i))", "coords", "f", track_length + 1, 2));
+	PyList_SetItem(dtype, idx++, Py_BuildValue("(s, s, (i, i))", "trajectory", "f", track_length, 2));
+	PyList_SetItem(dtype, idx++, Py_BuildValue("(s, s, i)", "hog", "f", 8 * cell_size));
+	PyList_SetItem(dtype, idx++, Py_BuildValue("(s, s, i)", "hof", "f", 9 * cell_size));
+	PyList_SetItem(dtype, idx++, Py_BuildValue("(s, s, i)", "mbh_x", "f", 8 * cell_size));
+	PyList_SetItem(dtype, idx++, Py_BuildValue("(s, s, i)", "mbh_y", "f", 8 * cell_size));
 	PyArray_Descr* descr;
 	PyArray_DescrConverter(dtype, &descr);
 	Py_DECREF(dtype);

--- a/dense_trajectory_release_v1.2/Makefile
+++ b/dense_trajectory_release_v1.2/Makefile
@@ -23,7 +23,7 @@ BINDIR := $(BUILD)
 # libraries 
 LDLIBS = $(addprefix -l, $(LIBS) $(LIBS_$(notdir $*)))
 LIBS := \
-	opencv_core opencv_highgui opencv_videoio opencv_imgproc \
+	opencv_core opencv_highgui opencv_videoio opencv_imgproc opencv_imgcodecs \
 	avformat avdevice avutil avcodec swscale \
 	python${PYTHON_VER}
 

--- a/densetrack.py
+++ b/densetrack.py
@@ -14,7 +14,7 @@ from numpy.ctypeslib import ndpointer
 PARENTDIR = os.path.dirname(__file__)
 LIBPATH = os.path.join(PARENTDIR, "dense_trajectory_release_v1.2", "release", "DenseTrack.so")
 
-_lib = ctypes.CDLL(LIBPATH)
+_lib = ctypes.PyDLL(LIBPATH)
 
 _densetrack = _lib.densetrack
 _densetrack.argtypes = [

--- a/densetrack.py
+++ b/densetrack.py
@@ -6,6 +6,7 @@ https://docs.python.org/3/library/ctypes.html
 """
 import ctypes
 import os
+import locale
 
 import numpy as np
 import pandas as pd
@@ -30,7 +31,7 @@ _densetrack.argtypes = [
     ctypes.c_int,        # scale_num
     ctypes.c_int,        # init_gap
     ctypes.c_int,        # poly_n
-    ctypes.c_double      # poly_sigma
+    ctypes.c_double,     # poly_sigma
     ctypes.c_char_p      # image_pattern
 ]
 _densetrack.restype = ctypes.py_object

--- a/densetrack.py
+++ b/densetrack.py
@@ -31,6 +31,7 @@ _densetrack.argtypes = [
     ctypes.c_int,        # init_gap
     ctypes.c_int,        # poly_n
     ctypes.c_double      # poly_sigma
+    ctypes.c_char_p      # image_pattern
 ]
 _densetrack.restype = ctypes.py_object
 
@@ -46,6 +47,7 @@ def densetrack(
         init_gap=1,
         poly_n=7,
         poly_sigma=1.5,  # used in Farneback method in C++ code
+        image_pattern=None
 ):
     """Compute dense trajectories for video.
 
@@ -109,10 +111,11 @@ def densetrack(
     if not video.flags['C_CONTIGUOUS']:
         video = np.ascontiguousarray(video)
 
+    image_pattern = image_pattern and image_pattern.encode(locale.getdefaultlocale()[1] or 'UTF-8')
     data = _densetrack(
         video, video.shape[0], video.shape[1], video.shape[2],
         track_length, min_distance, patch_size, nxy_cell, nt_cell, scale_num, init_gap,
-        poly_n, poly_sigma
+        poly_n, poly_sigma, image_pattern
     )
 
     # tracks = [dict(zip(ret_fields, track)) for track in data]  # uncomment to return list


### PR DESCRIPTION
This introduces a new parameter `image_pattern` that saves the images with overlaid tracks instead of displaying them. All file extensions supported by `cv::imsave` may be used. The pattern includes `%d` or `%0Nd` to include the frame number in the file name. Directories specified as part of the pattern are created. A Python exception will be thrown if there is an error creating directories or saving images.

This PR includes all the commits from #3 so that that PR wouldn't be needed.